### PR TITLE
Fix vault "reset" -> "purge" in first steps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ Den Zugang bekommt man von der gematik.
 .Einen neuen Vault für die Geheimnisse erstellen
 [source,bash]
 ----
-vzd-cli admin vault reset
+vzd-cli admin vault purge
 ----
 
 .Client Credentials für die jeweiligen Umgebungen hinterlegen


### PR DESCRIPTION
Mit 0.16.0 wie auch 2.0.0-alpha1 kommt:
```
$ vzd-cli admin vault reset
Usage: vzd-cli admin vault [OPTIONS] COMMAND [ARGS]...

Error: no such subcommand: "reset"
```

Ansonsten sehr praktisches kleines Tool! 👍 