### PR TITLE
Added delay and concurrency parameters to dump ocsp command

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = Changelog `vzd-cli`
 
+== Version 3.2.1
+
+- `dump ocsp` hat nun die beiden Parameter `--delay INT` und `--concurrency INT`
+
 == Version 3.2.0
 
 - Client kann jetzt als Backend for Frontend (BFF) für die Web-GUI verwendet werden `vzd-cli bff start`. Konfiguration erfolgt über die Umgebungsvariablen.

--- a/README.adoc
+++ b/README.adoc
@@ -538,7 +538,20 @@ Lädt große Mengen von Einträgen und schreibt sie in `STDOUT`, eine Zeile per 
 
 === `vzd-cli admin <tu|ru|pu> dump ocsp`
 
-Liest die Einträga aus STDIN, stellt für jeden gefundenen Zertifikat eine OCSP-Abfrage.
+Liest die Einträge aus STDIN, stellt für jeden gefundenen Zertifikat eine OCSP-Abfrage.
+
+Es gibt zwei Parameter für diesen Command:
+
+[source,bash]
+----
+# Setzt den delay zwischen Anfragen auf 500 Millisekunden 
+vzd-cli admin ru dump ocsp --delay 500
+
+# Setzt die Anzahl an gleichzeitig Request versendenden Coroutines
+vzd-cli admin ru dump ocsp --concurrency 5
+----
+
+Es sind auch beide Parameter gleichzeitig setzbar.
 
 === `vzd-cli admin <tu|ru|pu> log`
 


### PR DESCRIPTION
To avoid possible ratelimiting by OCSP responders a `--delay` and `--concurrency` parameter have been implemented.
`--delay INT` waits in a coroutine to delay the start of the next request.
`--concurrency INT` sets the count of semaphores, setting the count of concurrent requests. 